### PR TITLE
Remove `.gitkeep`. Add `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
1. Remove .`gitkeep` as it's no longer needed. It was added so that an empty directory could be committed to git. That directory is no longer empty so removing `.gitkeep` won't have any negative consequences. 
2. Add `.gitattributes` for Solidity syntax highlighting on Github. I learned about this from [your Contracts repo](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/.gitattributes). You can see a [working example here](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/ownership/Ownable.sol).